### PR TITLE
Support for UnityEvents

### DIFF
--- a/Assets/TimelineEvents/Scripts/TimelineEvents/Editor/TimelineEventDrawer.cs
+++ b/Assets/TimelineEvents/Scripts/TimelineEvents/Editor/TimelineEventDrawer.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using Tantawowa.Extensions;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace Tantawowa.TimelineEvents.Editor
 {
@@ -80,6 +81,17 @@ namespace Tantawowa.TimelineEvents.Editor
 
             invokeEventsInEditModeProperty.boolValue = EditorGUILayout.Toggle("Invoke in Edit Mode",
                 invokeEventsInEditModeProperty.boolValue);
+
+            EditorGUILayout.Space();
+
+            var proxy = new SerializedObject(TimelineEventProxy.Instance);
+            proxy.Update();
+            int index = TimelineEventProxy.Instance.IndexOfClip(clip);
+            SerializedProperty unityEvent = proxy.FindProperty("events").GetArrayElementAtIndex(index);
+
+            EditorGUILayout.PropertyField(unityEvent, new GUIContent("Unity Event"));
+            proxy.ApplyModifiedProperties();        
+        
         }
 
         private MethodInfo AddMethodsPopup(string label, SerializedProperty property, GameObject gameObject,

--- a/Assets/TimelineEvents/Scripts/TimelineEvents/EventInvocationInfo.cs
+++ b/Assets/TimelineEvents/Scripts/TimelineEvents/EventInvocationInfo.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reflection;
 using Tantawowa.Extensions;
 using UnityEngine;
+using UnityEngine.Events;
 
 namespace Tantawowa.TimelineEvents
 {
@@ -11,18 +12,19 @@ namespace Tantawowa.TimelineEvents
         public Behaviour TargetBehaviour;
         public MethodInfo MethodInfo;
         public static Type[] SupportedTypes = {typeof(string), typeof(float), typeof(int), typeof(bool)};
-
+        public UnityEvent unityEvent;
         //used for tracking
         public string Key;
 
-        public EventInvocationInfo(string key, Behaviour targetBehaviour, MethodInfo methodInfo)
+        public EventInvocationInfo(string key, Behaviour targetBehaviour, MethodInfo methodInfo, UnityEvent unityEvent)
         {
             Key = key;
             MethodInfo = methodInfo;
             TargetBehaviour = targetBehaviour;
+            this.unityEvent = unityEvent;
         }
 
-        public void Invoke(object value)
+        private void Invoke(object value)
         {
             if (MethodInfo != null)
             {
@@ -30,7 +32,7 @@ namespace Tantawowa.TimelineEvents
             }
         }
 
-        public void InvokEnum(int value)
+        private void InvokEnum(int value)
         {
             var type = MethodInfo.GetParameters()[0].ParameterType;
             var enumValue = Enum.ToObject(type, value);
@@ -38,9 +40,9 @@ namespace Tantawowa.TimelineEvents
             {
                 MethodInfo.Invoke(TargetBehaviour, new[] {enumValue});
             }
-        }
+       }
 
-        public void InvokeNoArgs()
+        private void InvokeNoArgs()
         {
             if (MethodInfo != null)
             {
@@ -52,6 +54,11 @@ namespace Tantawowa.TimelineEvents
         {
             try
             {
+                if (unityEvent != null)
+                {
+                    unityEvent.Invoke();
+                }
+
                 if (isSingleArg)
                 {
                     var paramType = MethodInfo.GetParameters()[0].ParameterType;

--- a/Assets/TimelineEvents/Scripts/TimelineEvents/TimelineEventBehaviour.cs
+++ b/Assets/TimelineEvents/Scripts/TimelineEvents/TimelineEventBehaviour.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
+using UnityEngine.Events;
 using UnityEngine.Playables;
 
 namespace Tantawowa.TimelineEvents
@@ -30,6 +31,8 @@ namespace Tantawowa.TimelineEvents
         /// value of the argument to use - it's serialized to and from string
         /// </summary>
         public string ArgValue;
+
+        public TimelineEventClip clip;
 
         private EventInvocationInfo invocationInfo;
 
@@ -80,7 +83,9 @@ namespace Tantawowa.TimelineEvents
                     .GetMethods(BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.Instance)
                     .FirstOrDefault(m => m.Name == methodName && m.ReturnType == typeof(void) &&
                                          m.GetParameters().Length == (methodWitharg ? 1 : 0));
-                return new EventInvocationInfo(methodKey, targetBehaviour, methodInfo);
+
+                var unityEvent = TimelineEventProxy.Instance.EventForClip(clip);
+                return new EventInvocationInfo(methodKey, targetBehaviour, methodInfo, unityEvent);
             }
 
             return null;

--- a/Assets/TimelineEvents/Scripts/TimelineEvents/TimelineEventClip.cs
+++ b/Assets/TimelineEvents/Scripts/TimelineEvents/TimelineEventClip.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using UnityEngine.Events;
 using UnityEngine.Playables;
 using UnityEngine.Timeline;
 
@@ -21,6 +22,11 @@ namespace Tantawowa.TimelineEvents
             var playable = ScriptPlayable<TimelineEventBehaviour>.Create(graph, template);
             TimelineEventBehaviour clone = playable.GetBehaviour();
             clone.TargetObject = TrackTargetObject;
+
+            clone.clip = this;
+
+            TimelineEventProxy.Instance.EventForClip(this);
+
             return playable;
         }
     }

--- a/Assets/TimelineEvents/Scripts/TimelineEvents/TimelineEventProxy.cs
+++ b/Assets/TimelineEvents/Scripts/TimelineEvents/TimelineEventProxy.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace Tantawowa.TimelineEvents
+{
+    [ExecuteInEditMode]
+    public class TimelineEventProxy : MonoBehaviour
+    {
+        //THIS SHOULD NOT BE DONE THIS WAY
+        //YET, I DID.
+        //TODO: FIX MESS.
+        private static TimelineEventProxy instance;
+        public static TimelineEventProxy Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = FindObjectOfType<TimelineEventProxy>();
+                    if(instance == null)
+                    {
+                        var go = new GameObject();
+                        go.name = typeof(TimelineEventProxy).Name;
+                        instance = go.AddComponent<TimelineEventProxy>();
+                    }
+                }
+                return instance;
+            }
+        }
+
+        //Why this is not a dictionary:
+        //1-Serializables (even though there are serializable implementations out there...)
+        //2-SerializedProperty can't dig through a dictionary (I think) it needs something indexed.
+        //2.b they are private so no other class would mess with them, because they need to be in sync
+        //2.c Hidden in inspector so one mess with it.
+
+        [SerializeField]
+        [HideInInspector]
+        private List<UnityEvent> events = new List<UnityEvent>();
+        [SerializeField]
+        [HideInInspector]
+        private List<TimelineEventClip> clips = new List<TimelineEventClip>();
+
+        public UnityEvent EventForClip(TimelineEventClip clip)
+        {
+            if (clip == null)
+                return null;
+
+            if (!clips.Contains(clip))
+            {
+                clips.Add(clip);
+                events.Add(new UnityEvent());
+            }
+            return events[clips.IndexOf(clip)];
+        }
+
+        public int IndexOfClip(TimelineEventClip clip)
+        {
+            if (clip == null)
+                return -1;
+
+            return clips.IndexOf(clip);
+        }
+
+    }
+}

--- a/Assets/TimelineEvents/Scripts/TimelineEvents/TimelineEventProxy.cs.meta
+++ b/Assets/TimelineEvents/Scripts/TimelineEvents/TimelineEventProxy.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: e456e0643a66f494fbc8de109203fc45
+timeCreated: 1523333630
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Basically a "proxy" where events are living on a scene object holding a list of events, one for each clip.

In the case of using clips on different timelines (director, aka difference instances of the same clip), or difference scenes etc indexing the clips should be different.

Example:
Right now, events are mapped like this:
For each clip (Asset) => Unity event

It would be more practical for it to be
For each (clip (Asset) + timeline (scene object))  => Unity event

this way events of one timeline instance doesn't interfere with the others, like when two playables refer to the same clip  (I hope I'm not speaking garbage, as my experience with timeline is not that vast)

Cheers!